### PR TITLE
fix(key): use correct units for key repeat timer

### DIFF
--- a/src/wayland.zig
+++ b/src/wayland.zig
@@ -505,10 +505,11 @@ fn repeatCallback(
         return .disarm;
     };
     const timer = xev.Timer.init() catch unreachable;
+    const repeat_time = @divFloor(1000, surface.repeat_rate);
     timer.run(
         l,
         c,
-        @intCast(surface.repeat_rate),
+        @intCast(repeat_time),
         Surface,
         surface,
         repeatCallback,


### PR DESCRIPTION
The repeat_rate reported by wayland is in units of keys per second. The
units required for a libxev.Timer are ms. Calculate the correct timer
value to get the correct repeat rate.

Signed-off-by: Tim Culverhouse <tim@timculverhouse.com>
