### PR TITLE
fix: only call focusCallback for keyboard enter and leave events

### DIFF
--- a/src/wayland.zig
+++ b/src/wayland.zig
@@ -82,12 +82,6 @@ fn pointerListener(wl_pointer: *wl.Pointer, event: wl.Pointer.Event, seat: *Seat
             surface.cursor_shape_device = surface.app.cursor_shape_manager.getPointer(wl_pointer) catch null;
             surface.pointer_serial = ev.serial;
             surface.setCursorShape(surface.core_surface.io.terminal.mouse_shape);
-            surface.core_surface.focusCallback(true) catch |err| {
-                log.err(
-                    "error in focus callback err={}",
-                    .{err},
-                );
-            };
             surface.core_surface.cursorPosCallback(.{
                 .x = @floatCast(x),
                 .y = @floatCast(y),
@@ -101,12 +95,6 @@ fn pointerListener(wl_pointer: *wl.Pointer, event: wl.Pointer.Event, seat: *Seat
         },
         .leave => {
             const surface = seat.surface orelse return;
-            surface.core_surface.focusCallback(false) catch |err| {
-                log.err(
-                    "error in focus callback err={}",
-                    .{err},
-                );
-            };
             surface.cursor_x = -1;
             surface.cursor_y = -1;
             surface.core_surface.cursorPosCallback(.{


### PR DESCRIPTION
The focusCallback in Ghostty should only be called when we gain or lose
keyboard focus. This affects how the cursor is displayed - it will be an
outline when we don't have *keyboard* focus. The current implementation
can retain keyboard focus, draw an outlined cursor, but receive key
events.

To reproduce, open a ghostty-wayland terminal in sway and move the mouse
directly from the terminal to a bar. The mouse leaves the terminal but
the keyboard focus stays in the terminal. For this case we want the
cursor to render solid.
